### PR TITLE
missing quotes around string on line 117

### DIFF
--- a/ffmpeg-node.js
+++ b/ffmpeg-node.js
@@ -114,7 +114,7 @@ exports.convert = function (/* overloaded */) {
          params = arguments[2];
          callback = arguments[3];
       }
-      else if (typeof arguments[2] === string &&
+      else if (typeof arguments[2] === 'string' &&
          arguments[3] instanceof Function) {
 
          output = arguments[2];


### PR DESCRIPTION
`typeof` check on line 117 throws error with ffmpeg.call because the word string was missing its quotes.
