### PR TITLE
Fix exec method params document

### DIFF
--- a/ffmpeg-node.js
+++ b/ffmpeg-node.js
@@ -37,7 +37,7 @@ function next () {
  *    to the callback function.
  *
  * Parameters:
- * params - an object of ffmpeg options, ex: {'-i': './test.3gp', '-vpre': ['slow', 'baseline'], '-vcodec': 'libx264'}
+ * params - an array of ffmpeg options, ex, ['-i', './test.3gp', '-vpre', 'slow', '-vpre', 'baseline', '-vcodec', 'libx264']
  * callback - a function to call when ffmpeg is done, ex:
  *    function (stderr, stdout, exitCode) { ... }
  */


### PR DESCRIPTION
In `exports.exec`document, 'params' is written as object(hash), but the method checks whether `params` is `Array` 
https://github.com/xonecas/ffmpeg-node/blob/master/ffmpeg-node.js#L46
https://github.com/xonecas/ffmpeg-node/blob/master/ffmpeg-node.js#L66

So, I fixed the `params` example object to array.